### PR TITLE
Added convenience method .tapError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ RUNNING_PID
 .metals
 .bsp
 .junie
+.bloop
+.vscode
+**metals.sbt

--- a/modules/examples/src/main/scala-2/examples/BasicHandlingExample.scala
+++ b/modules/examples/src/main/scala-2/examples/BasicHandlingExample.scala
@@ -18,6 +18,7 @@ package examples
 
 import cats.effect.{IO, IOApp}
 import iohandle.{IORaise, ioAbort, ioHandling}
+import iohandle.IOExtensionForIOHandle
 
 /** This example shows the usage of IORaise in function signatures to accurately codify the error that can be raised
   * within the function
@@ -33,14 +34,19 @@ object BasicHandlingExample extends IOApp.Simple {
 
   def checkNumber(num: Int): IO[Unit] = {
     ioHandling[NumberCheckError] { implicit handle =>
-      for {
-        _ <- checkEven(num)
-        _ <- checkDivisbleBy7(num)
-        _ <- IO.println(s"$num is even and divisible by 7!")
-      } yield ()
+      {  
+        for {
+          _ <- checkEven(num)
+          _ <- checkDivisbleBy7(num)
+          _ <- IO.println(s"$num is even and divisible by 7!")
+        } yield ()
+      }
+      .tapError { e: NumberCheckError => 
+        IO.println(s"There is a number check error: ${e.getMessage()}")
+      }
     }
-      .rescueWith { e =>
-        IO.println(e.getMessage)
+      .rescueWith { _ =>
+        IO.unit // just ignore the error
       }
   }
 

--- a/modules/examples/src/main/scala-3/examples/BasicHandlingExample.scala
+++ b/modules/examples/src/main/scala-3/examples/BasicHandlingExample.scala
@@ -33,13 +33,17 @@ object BasicHandlingExample extends IOApp.Simple {
 
   def checkNumber(num: Int): IO[Unit] =
     ioHandling[NumberCheckError]:
-      for
-        _ <- checkEven(num)
-        _ <- checkDivisbleBy7(num)
-        _ <- IO.println(s"$num is even and divisible by 7!")
-      yield ()
+      {
+        for
+          _ <- checkEven(num)
+          _ <- checkDivisbleBy7(num)
+          _ <- IO.println(s"$num is even and divisible by 7!")
+        yield ()
+      }.tapError { e: NumberCheckError =>
+        IO.println(s"There is a number check error: ${e.getMessage()}")
+      }
     .rescueWith: e =>
-      IO.println(e.getMessage)
+      IO.unit // just ignore the error
 
   def checkEven(num: Int)(implicit raise: IORaise[NotEven]): IO[Unit] =
     if (num % 2 != 0) ioAbort(NotEven(num)) else IO.unit

--- a/modules/iohandle/src/main/scala-2/iohandle/iohandle.scala
+++ b/modules/iohandle/src/main/scala-2/iohandle/iohandle.scala
@@ -110,6 +110,9 @@ package object iohandle {
       * [[iohandle.IOHandleErrorWrapper]] (it is automatically re-raised without exposing it to the user)
       */
     def handleUnexpectedWith[B >: A](f: Throwable => IO[B]): IO[B] = IOHandleExtensionImpl.handleUnexpectedWith(io, f)
+
+    def tapError[E](f: E => IO[A])(implicit handler: IOHandle[E]): IO[A] =
+      handler.handleWith(io){ e => f(e) *> handler.raise(e) }
   }
 
   /** Extension methods available on a IO[Option[A]] value, for convenience */


### PR DESCRIPTION
Added convenience method `.tapError` which allows user to call a side effect in case when error is raised.
Also updated the example correspondingly.

Example:
```
    ioHandling[NumberCheckError] { implicit handle =>
      {  
        for {
          _ <- checkEven(num)
          _ <- checkDivisbleBy7(num)
          _ <- IO.println(s"$num is even and divisible by 7!")
        } yield ()
      }
      .tapError { e: NumberCheckError => 
        IO.println(s"There is a number check error: ${e.getMessage()}")
      }
    }
```